### PR TITLE
Drop ie8 styles

### DIFF
--- a/app/_components/site-search/_site-search.scss
+++ b/app/_components/site-search/_site-search.scss
@@ -12,30 +12,28 @@
 
 $icon-size: 40px;
 
-@include govuk-not-ie8 {
-  .app-site-search {
-    position: relative;
-    width: 100%;
-    margin-bottom: govuk-spacing(2);
-    float: left;
+.app-site-search {
+  position: relative;
+  width: 100%;
+  margin-bottom: govuk-spacing(2);
+  float: left;
 
-    @include govuk-media-query($from: 900px) {
-      float: right;
-      margin: 0;
-      margin-top: -5px; // Negative margin to vertically align search in header
-      width: 300px;
+  @include govuk-media-query($from: 900px) {
+    float: right;
+    margin: 0;
+    margin-top: -5px; // Negative margin to vertically align search in header
+    width: 300px;
+  }
+
+  .no-js & {
+    display: none;
+
+    @include govuk-media-query($from: tablet) {
+      display: block;
     }
 
-    .no-js & {
-      display: none;
-
-      @include govuk-media-query($from: tablet) {
-        display: block;
-      }
-
-      @include govuk-media-query($from: 900px) {
-        text-align: right;
-      }
+    @include govuk-media-query($from: 900px) {
+      text-align: right;
     }
   }
 
@@ -212,27 +210,5 @@ $icon-size: 40px;
     display: inline-block;
     margin-right: govuk-spacing(1);
     margin-left: govuk-spacing(1);
-  }
-}
-
-// on IE8 we show the sitemap link as Accessible autocomplete
-// does not support it
-@include govuk-if-ie8 {
-  .app-site-search {
-    width: 300px;
-    margin: 0;
-    margin-top: -6px;
-    float: right;
-    text-align: right;
-  }
-
-  .app-site-search__link:link {
-    display: inline-block;
-    margin-top: 10px;
-    color: govuk-colour("white");
-
-    &:focus {
-      color: govuk-colour("black");
-    }
   }
 }

--- a/app/_stylesheets/application-ie8.scss
+++ b/app/_stylesheets/application-ie8.scss
@@ -1,3 +1,0 @@
-$govuk-is-ie8: true;
-
-@import "application";


### PR DESCRIPTION
IE8 is no longer officially supported, and the `govuk-not-ie8` and `govuk-if-ie8` mixins have been deprecated and will be dropped in govuk-frontend v5.