### PR TITLE
Build site within default _site folder

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,6 @@ module.exports = function (eleventyConfig) {
       match: /\/image\/(\d+)(x)?(\d+)?/g,
       replace: '/images'
     }],
-    serveStatic: ['public'],
     serveStaticOptions: {
       extensions: ['html']
     }
@@ -46,7 +45,6 @@ module.exports = function (eleventyConfig) {
     markdownTemplateEngine: 'njk',
     dir: {
       input: 'app',
-      output: 'public',
       layouts: '_layouts',
       includes: '_components'
     },

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Folders to ignore
 node_modules
-public
+_site
 .DS_Store

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: http-server -p $PORT
+web: http-server _site -p $PORT


### PR DESCRIPTION
This is the default for Eleventy, and seems to be expected by the GitHub workflow for publishing to GitHub Pages