### PR TITLE
Use node modules folder for import

### DIFF
--- a/app/_stylesheets/application.scss
+++ b/app/_stylesheets/application.scss
@@ -1,7 +1,7 @@
 $govuk-global-styles: true;
 $govuk-new-link-styles: true;
 
-@import "govuk/all.scss";
+@import "node_modules/govuk-frontend/govuk/all";
 @import "_components/all.scss";
 @import "vendor/prism.scss";
 


### PR DESCRIPTION
This is now [the recommended way to import the css from govuk-frontend](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#import-css-assets-and-javascript).