### PR TITLE
Remove tags for service collections

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,6 +17,23 @@ module.exports = function (eleventyConfig) {
     }
   })
 
+  // Collections of posts for each service
+  eleventyConfig.addCollection('manage-training', collection => {
+    return collection.getFilteredByGlob('app/posts/manage-training/*.md')
+  })
+
+  eleventyConfig.addCollection('manage-cpd-delivery', collection => {
+    return collection.getFilteredByGlob('app/posts/manage-cpd-delivery/*.md')
+  })
+
+  eleventyConfig.addCollection('register-for-an-npq', collection => {
+    return collection.getFilteredByGlob('app/posts/register-for-an-npq/*.md')
+  })
+
+  eleventyConfig.addCollection('support-for-cpd', collection => {
+    return collection.getFilteredByGlob('app/posts/support-for-cpd/*.md')
+  })
+
   // Browser Sync
   eleventyConfig.setBrowserSyncConfig({
     rewriteRules: [{

--- a/app/posts/manage-cpd-delivery/manage-cpd-delivery.json
+++ b/app/posts/manage-cpd-delivery/manage-cpd-delivery.json
@@ -1,5 +1,4 @@
 {
-  "tags": ["manage-cpd-delivery"],
   "eleventyNavigation": {
     "parent": "Lead provider, delivery partner, and appropriate body services"
   }

--- a/app/posts/manage-training/manage-training.json
+++ b/app/posts/manage-training/manage-training.json
@@ -1,5 +1,4 @@
 {
-  "tags": ["manage-training"],
   "eleventyNavigation": {
     "parent": "Manage training for early career teachers"
   }

--- a/app/posts/posts.json
+++ b/app/posts/posts.json
@@ -1,7 +1,6 @@
 {
   "layout": "post",
   "permalink": "{{ page.filePathStem | replace('posts/', '') }}/",
-  "tags": ["search-index"],
   "eleventyComputed": {
     "eleventyNavigation": {
       "key": "{{ title }}",

--- a/app/posts/register-for-an-npq/register-for-an-npq.json
+++ b/app/posts/register-for-an-npq/register-for-an-npq.json
@@ -1,5 +1,4 @@
 {
-  "tags": ["register-for-an-npq"],
   "eleventyNavigation": {
     "parent": "Register for an NPQ"
   }

--- a/app/posts/support-for-cpd/support-for-cpd.json
+++ b/app/posts/support-for-cpd/support-for-cpd.json
@@ -1,5 +1,4 @@
 {
-  "tags": ["support-for-cpd"],
   "eleventyNavigation": {
     "parent": "Support services"
   }


### PR DESCRIPTION
This stops the tags appearing on the index pages, and allows us to use tags for navigation.