### PR TITLE
Create naming-the-service design history entry

### DIFF
--- a/app/posts/ecf-v2/naming-the-service.md
+++ b/app/posts/ecf-v2/naming-the-service.md
@@ -30,39 +30,39 @@ Our data insights team also identified the most used search terms for the ECF se
 
 ### Feedback form: Top 5 most used terms 
 
-Registration 
+1. Registration 
 
-Induction process 
+2. Induction process 
 
-ECT induction 
+3. ECT induction 
 
-Mentor training 
+4. Mentor training 
 
-Data entry 
+5. Data entry 
 
 ### Helpdesk emails: Top 5 most used terms 
 
-Portal or DfE portal 
+1. Portal or DfE portal 
 
-Add an ECT 
+2. Add an ECT 
 
-Induction 
+3. Induction 
 
-Add a mentor 
+4. Add a mentor 
 
-Lead provider 
+5. Lead provider 
 
 ### Search term findings: Top 5 most used terms 
 
-DfE ECT registration 
+1. DfE ECT registration 
 
-DfE ECT portal 
+2. DfE ECT portal 
 
-DfE register ECT 
+3. DfE register ECT 
 
-DfE ECT 
+4. DfE ECT 
 
-DfE portal ECT 
+5. DfE portal ECT 
 
 ## Initial naming concepts 
 
@@ -84,13 +84,13 @@ Based on feedback, we made adjustments, weighed the pros and cons of different n
 
 We felt that keeping the name short would provide clarity and make it more memorable, so we decided not to include ‘mentors’ in the name. Instead, we described how the service supports mentors after the start page heading: 
 
-‘Use this service to register your ECTs for the early career framework (ECF) training and mentors for mentor training. 
+'Use this service to register your ECTs for the early career framework (ECF) training and mentors for mentor training. 
 
 You need to register your ECTs and their mentors with the Department for Education (DfE) so that they can get: 
 
 * access to DfE-funded training 
 
-* funding to support their time off timetable for mentoring and training’ 
+* funding to support their time off timetable for mentoring and training’
 
 ## Future considerations 
 

--- a/app/posts/ecf-v2/naming-the-service.md
+++ b/app/posts/ecf-v2/naming-the-service.md
@@ -1,0 +1,99 @@
+---
+title: Naming the 'Register early career teachers' service
+description: "We needed a name for our service that clearly defines its purpose and resonates with users. This entry explains why we chose ‘Register early career teachers’ and outlines the research and feedback that informed our decision."
+date: 2024-10-16
+---
+
+## Introduction 
+
+We needed a name for our service that clearly defines its purpose and resonates with users. This entry explains why we chose ‘Register early career teachers’ and outlines the research and feedback that informed our decision. 
+
+## Why we renamed the service 
+
+There are multiple services that facilitate the early career teaching reforms. We’re working on rebuilding these services. Our priority was to develop a name for the new service for schools, which are responsible for submitting information about early career teachers and mentors to the Department for Education (DfE). Our user research showed that users found the existing service start page and the name ‘Manage training for early career teachers’ confusing, highlighting that we were not fully meeting the needs of all user groups involved. 
+
+## Objective 
+
+The primary role of school users in this service is to register the enrolment of early career teachers onto the early career framework programme and to register mentors with the Department for Education.  
+
+Our objective was to develop a name that clearly communicates this core function, using language that users are familiar with. Additionally, we aimed to make the service easily discoverable through organic search. 
+
+## Research: understanding user language 
+
+To create a user-friendly name, we analysed the language used by our audience through two main channels: 
+
+* feedback forms from the first early career framework (ECF) service 
+
+* helpdesk email communications 
+
+Our data insights team also identified the most used search terms for the ECF service. 
+
+### Feedback form: Top 5 most used terms 
+
+Registration 
+
+Induction process 
+
+ECT induction 
+
+Mentor training 
+
+Data entry 
+
+### Helpdesk emails: Top 5 most used terms 
+
+Portal or DfE portal 
+
+Add an ECT 
+
+Induction 
+
+Add a mentor 
+
+Lead provider 
+
+### Search term findings: Top 5 most used terms 
+
+DfE ECT registration 
+
+DfE ECT portal 
+
+DfE register ECT 
+
+DfE ECT 
+
+DfE portal ECT 
+
+## Initial naming concepts 
+
+In a workshop with the team, we brainstormed names based on user research. We focused on the primary actions each user group performs and aimed to centre the name around those tasks.  
+
+For the induction tutor service, terms like ‘register’ and ‘ECT’ were frequently used and stood out as key descriptors. We felt these should be included in the name for better search engine optimisation and clarity.  
+
+After discussion, we proposed the name ‘Register early career teachers (ECTs).’ 
+
+## Testing and feedback 
+
+We shared this proposed name with the wider teacher services community. Feedback included suggestions to incorporate the role of mentors, resulting in alternatives like 'Register early career teachers (ECTs) and mentors'.  
+
+We also tested the name in user research sessions, where schools felt it adequately described the purpose of the service. However, some participants expected a noun-based name, like ‘The DfE Portal’ or ‘Portal.’ 
+
+## Refinement and iteration 
+
+Based on feedback, we made adjustments, weighed the pros and cons of different naming options, and ultimately refined the name to its final form. We removed ‘(ECT)’ from the name, despite the term being frequently used to find the service. Instead, we used 'ECT' consistently throughout the start page to enhance the page’s optimisation for search engines. 
+
+We felt that keeping the name short would provide clarity and make it more memorable, so we decided not to include ‘mentors’ in the name. Instead, we described how the service supports mentors after the start page heading: 
+
+‘Use this service to register your ECTs for the early career framework (ECF) training and mentors for mentor training. 
+
+You need to register your ECTs and their mentors with the Department for Education (DfE) so that they can get: 
+
+* access to DfE-funded training 
+
+* funding to support their time off timetable for mentoring and training’ 
+
+## Future considerations 
+
+We need to assess whether our users are able to find and access our service, as changing the name of a service can be jarring for some users. If the name does not perform well, we will need to iterate based on user feedback. 
+
+ 


### PR DESCRIPTION
This is adding Dom's design history entry into how we named the Register early career teachers service.

To review, make sure it's all linked up properly and there's no spelling or grammar mistakes.